### PR TITLE
Update ViewportProvider.md

### DIFF
--- a/docs/api/ViewportProvider.md
+++ b/docs/api/ViewportProvider.md
@@ -20,7 +20,7 @@ import * as React from 'react';
 import {
   ViewportProvider,
   connectViewport,
-} from 'react-viewport-uitls';
+} from 'react-viewport-utils';
 
 const Component = ({ scroll, dimensions }) => (
   <>


### PR DESCRIPTION
I changed the example from react-viewport-uitls to react-viewport-utils on line 23, I found it to be useful for others wanting to use this example as well.