### PR TITLE
Update ViewportProvider.tsx

### DIFF
--- a/lib/ViewportProvider.tsx
+++ b/lib/ViewportProvider.tsx
@@ -22,6 +22,7 @@ import {
 interface Props {
   experimentalSchedulerEnabled?: boolean;
   experimentalSchedulerLayoutCalculatorEnabled?: boolean;
+  children?: React.ReactNode;
 }
 
 interface Listener extends ViewportChangeOptions {


### PR DESCRIPTION
Added a new optional `children` prop to be compliant with React18.

[The most notable change in React18 is that the `children` prop now needs to be listed explicitly when defining props,](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions)